### PR TITLE
Fix for HTML strings containing non-ASCII characters

### DIFF
--- a/NSAttributedString+DDHTML/NSAttributedString+DDHTML.m
+++ b/NSAttributedString+DDHTML/NSAttributedString+DDHTML.m
@@ -35,7 +35,10 @@
 
 + (NSAttributedString *)attributedStringFromHTML:(NSString *)htmlString boldFont:(UIFont *)boldFont
 {
-    xmlDoc *document = htmlReadMemory([htmlString cStringUsingEncoding:NSUTF8StringEncoding], htmlString.length, nil, NULL, HTML_PARSE_NOWARNING | HTML_PARSE_NOERROR);
+    // Parse HTML string as XML document using UTF-8 encoding
+    const char *encoding =[@"UTF-8" UTF8String];
+    NSData* documentData = [htmlString dataUsingEncoding:NSUTF8StringEncoding];
+    xmlDoc *document = htmlReadMemory([documentData bytes], [documentData length], nil, encoding, HTML_PARSE_NOWARNING | HTML_PARSE_NOERROR);    
     
     if (document == NULL)
         return nil;


### PR DESCRIPTION
As proposed by evg1985. Solves string truncation and/or crash issues with strings containing multibyte chararcters
