### PR TITLE
Fix sample project

### DIFF
--- a/HTMLToAttributedString/ViewController.m
+++ b/HTMLToAttributedString/ViewController.m
@@ -22,7 +22,7 @@
     [super viewDidLoad];
 	// Do any additional setup after loading the view, typically from a nib.
     
-    NSAttributedString *attrString = [NSAttributedString attributedStringFromHTML:@"<font face=\"Avenir-Heavy\" color=\"#FF0000\">This</font> <shadow>is</shadow> <b>Happy bold, <u>underlined</u> <stroke width=\"2.0\" color=\"#00FF00\">awesomeness </stroke><a href=\"https://www.google.com\">link</a>!</b>" boldFont:[UIFont boldSystemFontOfSize:12]];
+    NSAttributedString *attrString = [NSAttributedString attributedStringFromHTML:@"<font face=\"Avenir-Heavy\" color=\"#FF0000\">This</font> <shadow>is</shadow> <b>Happy bold, <u>underlined</u> <stroke width=\"2.0\" color=\"#00FF00\">awesomeness </stroke><a href=\"https://www.google.com\">link</a>!</b>" boldFont:[UIFont boldSystemFontOfSize:12] italicFont:[UIFont italicSystemFontOfSize:12]];
     self.label.attributedText = attrString;
 }
 


### PR DESCRIPTION
The sample project doesn't compile, which can be a non-starter for people checking out the project.

I added a missing parameter to the init method call in the sample project to resolve this.